### PR TITLE
Cross-platform fixes for the Skeleton Generator and the Bone Renamer

### DIFF
--- a/TK_FX.py
+++ b/TK_FX.py
@@ -9,6 +9,7 @@
 
 
 import bpy
+import os
 # from bpy import context
 from pathlib import Path
 import mathutils
@@ -97,13 +98,13 @@ def TekkenFBXexporter():
 
     Result = Test_SK_Type(SK)
 
-    Filepath = bpy.path.abspath("//") + '/' + filename + '.fbx'
+    File_Path = os.path.join(bpy.path.abspath("//") ,filename +'.fbx')
 
     if Result == "glTF":
-        bpy.ops.export_scene.fbx(filepath=Filepath, check_existing=True, filter_glob='*.fbx', use_selection=False, use_active_collection=False, global_scale=1.0, apply_unit_scale=True, apply_scale_options='FBX_SCALE_NONE', bake_space_transform=False, object_types={'ARMATURE', 'CAMERA', 'EMPTY', 'LIGHT', 'MESH', 'OTHER'}, use_mesh_modifiers=True, use_mesh_modifiers_render=True, mesh_smooth_type='FACE', use_subsurf=False, use_mesh_edges=False, use_tspace=True, use_custom_props=False, add_leaf_bones=False, primary_bone_axis='X', secondary_bone_axis='-Y', use_armature_deform_only=True, armature_nodetype='NULL', bake_anim=False, bake_anim_use_all_bones=True, bake_anim_use_nla_strips=True, bake_anim_use_all_actions=True, bake_anim_force_startend_keying=True, bake_anim_step=1.0, bake_anim_simplify_factor=1.0, path_mode='AUTO', embed_textures=False, batch_mode='OFF', use_batch_own_dir=True, use_metadata=True, axis_forward='-Z', axis_up='Y')
+        bpy.ops.export_scene.fbx(filepath=File_Path, check_existing=True, filter_glob='*.fbx', use_selection=False, use_active_collection=False, global_scale=1.0, apply_unit_scale=True, apply_scale_options='FBX_SCALE_NONE', bake_space_transform=False, object_types={'ARMATURE', 'CAMERA', 'EMPTY', 'LIGHT', 'MESH', 'OTHER'}, use_mesh_modifiers=True, use_mesh_modifiers_render=True, mesh_smooth_type='FACE', use_subsurf=False, use_mesh_edges=False, use_tspace=True, use_custom_props=False, add_leaf_bones=False, primary_bone_axis='X', secondary_bone_axis='-Y', use_armature_deform_only=True, armature_nodetype='NULL', bake_anim=False, bake_anim_use_all_bones=True, bake_anim_use_nla_strips=True, bake_anim_use_all_actions=True, bake_anim_force_startend_keying=True, bake_anim_step=1.0, bake_anim_simplify_factor=1.0, path_mode='AUTO', embed_textures=False, batch_mode='OFF', use_batch_own_dir=True, use_metadata=True, axis_forward='-Z', axis_up='Y')
         
     elif Result == "PSK":
-        bpy.ops.export_scene.fbx(filepath=Filepath, check_existing=True, filter_glob='*.fbx', use_selection=False, use_active_collection=False, global_scale=1.0, apply_unit_scale=True, apply_scale_options='FBX_SCALE_NONE', bake_space_transform=False, object_types={'ARMATURE', 'CAMERA', 'EMPTY', 'LIGHT', 'MESH', 'OTHER'}, use_mesh_modifiers=True, use_mesh_modifiers_render=True, mesh_smooth_type='FACE', use_subsurf=False, use_mesh_edges=False, use_tspace=True, use_custom_props=False, add_leaf_bones=False, primary_bone_axis='Y', secondary_bone_axis='X', use_armature_deform_only=True, armature_nodetype='NULL', bake_anim=False, bake_anim_use_all_bones=True, bake_anim_use_nla_strips=True, bake_anim_use_all_actions=True, bake_anim_force_startend_keying=True, bake_anim_step=1.0, bake_anim_simplify_factor=1.0, path_mode='AUTO', embed_textures=False, batch_mode='OFF', use_batch_own_dir=True, use_metadata=True, axis_forward='-Z', axis_up='Y')
+        bpy.ops.export_scene.fbx(filepath=File_Path, check_existing=True, filter_glob='*.fbx', use_selection=False, use_active_collection=False, global_scale=1.0, apply_unit_scale=True, apply_scale_options='FBX_SCALE_NONE', bake_space_transform=False, object_types={'ARMATURE', 'CAMERA', 'EMPTY', 'LIGHT', 'MESH', 'OTHER'}, use_mesh_modifiers=True, use_mesh_modifiers_render=True, mesh_smooth_type='FACE', use_subsurf=False, use_mesh_edges=False, use_tspace=True, use_custom_props=False, add_leaf_bones=False, primary_bone_axis='Y', secondary_bone_axis='X', use_armature_deform_only=True, armature_nodetype='NULL', bake_anim=False, bake_anim_use_all_bones=True, bake_anim_use_nla_strips=True, bake_anim_use_all_actions=True, bake_anim_force_startend_keying=True, bake_anim_step=1.0, bake_anim_simplify_factor=1.0, path_mode='AUTO', embed_textures=False, batch_mode='OFF', use_batch_own_dir=True, use_metadata=True, axis_forward='-Z', axis_up='Y')
         
 
 def ApplyPose():

--- a/TK_OP.py
+++ b/TK_OP.py
@@ -4,6 +4,7 @@
 
 # from re import T
 import bpy
+import os
 # import random
 from bpy.types import Operator#,PropertyGroup, UIList, Panel
 
@@ -539,13 +540,10 @@ class LIST_OT_BoneRename_DeleteItem(Operator):
         my_list.remove(index)
         context.scene.bone_rename_list_index = min(max(0, index - 1), len(my_list) - 1)
 
-        directory = bpy.utils.user_resource('SCRIPTS',path= "addons")
-        AddonFolder = GetAddonsFolderName_propfx()
+        AddonFolder_Path = GetAddonsFolderPath_propfx()
 
-        Path = 'Rename_Presets/'+ context.scene.preset_collection[int(context.scene.preset_enum)].RenameListPreset +'.txt'
-        GlobalPath = directory+'/'+AddonFolder+'/'+Path
-        
-        SaveBoneRenameList(GlobalPath, my_list)
+        File_Path = os.path.join(AddonFolder_Path,'Rename_Presets', context.scene.preset_collection[int(context.scene.preset_enum)].RenameListPreset +'.txt')
+        SaveBoneRenameList(File_Path , my_list)
 
         return{'FINISHED'}
 

--- a/TK_PROP_FX.py
+++ b/TK_PROP_FX.py
@@ -37,21 +37,30 @@ def GetAddonsFolderName_propfx():
     
     return addon_folder
 
+def GetAddonsFolderPath_propfx():
+    addon_folder_path = None
+    
+    for mod in addon_utils.modules():
+        if mod.bl_info.get('name') == "TK7_SK_CH":
+            addon_folder_path = os.path.dirname(mod.__file__)
+            break
+    
+    if addon_folder_path is None:
+        raise Exception("The TK7_SK_CH addon is not installed.")
+    
+    return addon_folder_path
+
 
 
 def FileExistenceTester(Folder,name):
 
-    script_file = os.path.realpath(__file__)
-    directory_ = os.path.dirname(script_file)
-
-    directory = bpy.utils.user_resource('SCRIPTS',path= "addons")
-    AddonFolder = GetAddonsFolderName_propfx()
+    AddonFolder_Path = GetAddonsFolderPath_propfx()
 
     #Tests if a txt file with the name 'name' exists in the folder called "Folder"
-    #Path = 'Rename_Presets/'+ name +'.txt'
-    Path = Folder+'/'+ name +'.txt'
-    GlobalPath = directory+'/'+AddonFolder+'/'+Path
-    return os.path.exists(GlobalPath)
+
+    File_Path = os.path.join(AddonFolder_Path, Folder, name +'.txt')
+
+    return os.path.exists(File_Path)
 
 def Find_File_Names(FolderName, FileType):
 
@@ -59,104 +68,67 @@ def Find_File_Names(FolderName, FileType):
     directory_ = os.path.dirname(script_file)
 
     directory = bpy.utils.user_resource('SCRIPTS',path= "addons")
-    AddonFolder = GetAddonsFolderName_propfx()
+    AddonFolder_Path = GetAddonsFolderPath_propfx()
 
-    GlobalPath = directory+'/'+AddonFolder+'/'+FolderName
-    # GlobalPath = AddonFolder+'/'+FolderName
-    # print("Global path1:",GlobalPath)
+    FolderPath = os.path.join(AddonFolder_Path, FolderName)
+
 
     File_Names = []
-    for root, dirs, files in os.walk(GlobalPath):
+    for root, dirs, files in os.walk(FolderPath):
         for file in files:
             if file.endswith(FileType):
-                # print(os.path.join(root, file))
 
-                
-                Path = os.path.join(root, file)
-                start = '\\'
-                end = '.'
-                PresetName = Path.split(start)[-1].split(end)[0]
+                PresetName = os.path.splitext(file)[0]
+
 
                 File_Names.append(PresetName)
     return File_Names
 
 def FileCreater(Folder,name):
 
-    script_file = os.path.realpath(__file__)
-    directory_ = os.path.dirname(script_file)
+    AddonFolder_Path = GetAddonsFolderPath_propfx()
 
-    directory = bpy.utils.user_resource('SCRIPTS',path= "addons")
-    AddonFolder = GetAddonsFolderName_propfx()
 
-    Path = Folder+'/'+ name +'.txt'
-    GlobalPath = directory+'/'+AddonFolder+'/'+Path
 
-    with open(GlobalPath,'w') as f:
+    File_Path = os.path.join(AddonFolder_Path ,Folder, name +'.txt')
+
+    with open(File_Path,'w') as f:
         pass
     return 
 
 def FileRenamer(Folder ,OldName, NewName):
-#Works fine
 
-    script_file = os.path.realpath(__file__)
-    directory_ = os.path.dirname(script_file)
+    AddonFolder_Path = GetAddonsFolderPath_propfx()
 
-    directory = bpy.utils.user_resource('SCRIPTS',path="addons")
-    AddonFolder = GetAddonsFolderName_propfx()
+    File_Path_old = os.path.join(AddonFolder_Path,Folder, OldName +'.txt')
 
-    old_name = Folder+'/'+ OldName +'.txt'
-    Global_old = directory+'/'+AddonFolder+'/'+old_name
-    new_name = Folder+'/'+ NewName +'.txt'
-    Global_new = directory+'/'+AddonFolder+'/'+new_name
+    File_Path_new = os.path.join(AddonFolder_Path,Folder, NewName +'.txt')
     # Renaming the file
-    os.rename(Global_old, Global_new)
+    os.rename(File_Path_old, File_Path_new)
 
 def FileRemover(Folder ,FileName):
-#Works fine
-    script_file = os.path.realpath(__file__)
-    directory_ = os.path.dirname(script_file)
 
-    directory = bpy.utils.user_resource('SCRIPTS',path= "addons")
-    AddonFolder = GetAddonsFolderName_propfx()
+    AddonFolder_Path = GetAddonsFolderPath_propfx()
 
-    Path = Folder+'/'+ FileName +'.txt'
+    File_Path = os.path.join(AddonFolder_Path,Folder, FileName +'.txt')
 
-    Global_old = directory+'/'+AddonFolder+'/'+Path
-    # new_name = Folder+'/'+ NewName +'.txt'
-    # Renaming the file
-    os.remove(Global_old)
+    os.remove(File_Path)
 
 def Find_Missing_File_Name(FolderName,Preset_Name_Collection):
 
     print("Missing file function invoked")
 
-    script_file = os.path.realpath(__file__)
-    directory_ = os.path.dirname(script_file)
+    AddonFolder_Path = GetAddonsFolderPath_propfx()
 
-    directory = bpy.utils.user_resource('SCRIPTS',path= "addons")
-    AddonFolder = GetAddonsFolderName_propfx()
-
-    GlobalPath = directory+'/'+AddonFolder+'/'+FolderName
-    # GlobalPath = AddonFolder+'/'+FolderName
-
-    # print("Global path 2:",GlobalPath)
+    Folder_Path = os.path.join(AddonFolder_Path,FolderName)
 
     File_Names = []
-    for root, dirs, files in os.walk(GlobalPath):
+    for root, dirs, files in os.walk(Folder_Path):
         for file in files:
             if file.endswith(".txt"):
-                # print(os.path.join(root, file))
-
-                
-                Path = os.path.join(root, file)
-                start = '\\'
-                end = '.'
-                PresetName = Path.split(start)[-1].split(end)[0]
-
+                PresetName = os.path.splitext(file)[0]
                 File_Names.append(PresetName)
 
-                # bpy.context.scene.preset_collection.add()
-                # bpy.context.scene.preset_collection[int(bpy.context.scene.preset_enum)].RenameListPreset = PresetName
 
     for FileName in File_Names:
         if FileName in Preset_Name_Collection:
@@ -180,7 +152,6 @@ def Generate_Enum_for_BoneMerger(self, context):
         Strindx = str(indx)
         item = (Strindx, data, '')
         
-        # Enum_items.append(item)
         Enums.append(item)
         
     return Enums
@@ -305,7 +276,6 @@ def Generate_Enum_for_SK_Gen_Opt2(self, context):
         Strindx = str(indx)
         item = (Strindx, data, '')
         
-        # Enum_items.append(item)
         Enums.append(item)
         
     return Enums
@@ -322,7 +292,6 @@ def Generate_Enum_for_SK_Gen_Opt1(self, context):
         Strindx = str(indx)
         item = (Strindx, data, '')
         
-        # Enum_items.append(item)
         Enums.append(item)
         
     return Enums
@@ -339,7 +308,6 @@ def Generate_Enum_for_Chars(self, context):
         Strindx = str(indx)
         item = (Strindx, data, '')
         
-        # Enum_items.append(item)
         Enums.append(item)
         
     return Enums
@@ -358,7 +326,6 @@ def Generate_Enum_for_ps_mode(self, context):
         Strindx = str(indx)
         item = (Strindx, data, '')
         
-        # Enum_items.append(item)
         Enums.append(item)
         
     return Enums
@@ -380,16 +347,7 @@ def collection_from_element(self):
         raise TypeError("Propery not element in a collection.") 
     else:
         return parent.path_resolve(coll_path) , index
-
-# def AddBoneRenameText(Path, Text):
-#     #TODO: Search where the line is located first, and if it's not already there, the lines are the indices. If it's there, change only that particular line 
-#     # Line = "'"+Current+"': '"+New+"'"
-       
-#     with open(Path,'w') as f:
-#         more_lines = ['', 'Append text files', 'The End']
-
-#         f.writelines('\n'.join(more_lines))
-#     return 
+ 
 
 
 def Generate_Enum_from_Rename_Preset_Collection(self, context):
@@ -409,14 +367,9 @@ def Generate_Enum_from_Rename_Preset_Collection(self, context):
 
 def InitializeBoneRenamerEnumerator():
 
-    # for root, dirs, files in os.walk("Skeletons"):
     PresetNames = Find_File_Names('Rename_Presets', ".txt")
     bpy.context.scene.preset_collection.clear()
 
-    # directory = bpy.utils.user_resource('SCRIPTS',path= "addons")
-    # AddonFolder = GetAddonsFolderName_propfx()
-    
-    # MaxLines = 0
 
 
     for file in PresetNames:
@@ -433,17 +386,11 @@ def InitializeBoneRenamerEnumerator():
 
 
 def SaveBoneRenameList(Path, collection):
-    directory = bpy.utils.user_resource('SCRIPTS',path= "addons")
-    AddonFolder = GetAddonsFolderName_propfx()
-
-    GlobalPath = directory+'/'+AddonFolder+'/'+Path
-
 
     Lines = []
     for item in collection:
             CurrentName = item.Current_Name
             NewName = item.New_Name
-            # print (CurrentName, NewName)
             Line = BoneRenameText(CurrentName, NewName)
             Lines.append(Line)
     
@@ -464,34 +411,27 @@ def CheckPresetNameMatch():
     PresetNames = []
     for preset in bpy.context.scene.preset_collection:
         PresetNames.append(preset.RenameListPreset)
-    # intersection = set(Files).intersection(PresetNames) 
-    # if len(intersection)==len(Files) and len(intersection)==len(Files):
+
     if set(Files) == set(PresetNames):
         return True
-    # else:
-    #     return False
+
 
 def BoneNameUpdateFunction(self, context):
     collection, indx = collection_from_element(self)
-    # print("Preset name assigned to:",self.RenameListPreset)
-    CurrentName = self.Current_Name
-    NewName = self.New_Name
-    # print (CurrentName, NewName)
-    Line = BoneRenameText(CurrentName, NewName)
-    Path = 'Rename_Presets/'+ context.scene.preset_collection[int(context.scene.preset_enum)].RenameListPreset +'.txt'
+
+    AddonFolder_Path = GetAddonsFolderPath_propfx()
+
+
+    File_Path = os.path.join(AddonFolder_Path,'Rename_Presets', context.scene.preset_collection[int(context.scene.preset_enum)].RenameListPreset +'.txt')
+
     
-    directory = bpy.utils.user_resource('SCRIPTS',path= "addons")
-    AddonFolder = GetAddonsFolderName_propfx()
-    # print("How are you")
-    GlobalPath = directory+'/'+AddonFolder+'/'+Path
-    
-    SaveBoneRenameList(GlobalPath, collection)
+    SaveBoneRenameList(File_Path, collection)
 
 
 def RenamePresetMainFunction(self, context):
     collection, indx = collection_from_element(self)
-    # print("Preset name assigned to:",self.RenameListPreset)
-    CurrentPresetName = self.RenameListPreset
+
+
     CollectionNames = []
     MatchFlag = False
     counter = 0
@@ -517,8 +457,7 @@ def RenamePresetUpdatedFunction(self, context):
 
     collection, indx = collection_from_element(self)
     FilePresent = FileExistenceTester('Rename_Presets',self.RenameListPreset)
-    # print("Preset name assigned to:",self.RenameListPreset)
-    CurrentPresetName = self.RenameListPreset
+
     CollectionNames = []
     MatchFlag = False
     counter = 0
@@ -636,24 +575,21 @@ def FillNewPreset():
                 
 
 def BoneRenamerPresetSelection(self, context):
-    # collection, indx = collection_from_element(self)
-    print("Preset Selected:",context.scene.preset_enum , context.scene.preset_collection[int(context.scene.preset_enum)].RenameListPreset)
-    Path = 'Rename_Presets/'+ context.scene.preset_collection[int(context.scene.preset_enum)].RenameListPreset +'.txt'
     startTime = time.time() 
     
-    print("Hi", time.time() - startTime)
-    directory = bpy.utils.user_resource('SCRIPTS',path= "addons")
-    AddonFolder = GetAddonsFolderName_propfx()
-    print("How are you", time.time() - startTime )
-    GlobalPath = directory+'/'+AddonFolder+'/'+Path
+    print("Start", time.time() - startTime)
+
     
+
+    AddonFolder_Path = GetAddonsFolderPath_propfx()
+    File_Path = os.path.join(AddonFolder_Path,'Rename_Presets', context.scene.preset_collection[int(context.scene.preset_enum)].RenameListPreset +'.txt')
    
+
     ClearBoneRenameList()
 
     print("After clearing the list", time.time() - startTime )
 
-    print(GlobalPath)
-    with open(GlobalPath,"r") as f:
+    with open(File_Path,"r") as f:
         Counter = 0
         lines = f.readlines()
         for line in lines:
@@ -666,8 +602,6 @@ def BoneRenamerPresetSelection(self, context):
                 bpy.context.scene.bone_rename_list[Counter].New_Name = ConvLine[1]
                 Counter +=1 
 
-                # print(ConvLine, len(ConvLine))
-    # Call function to load preset by changing bone_rename_list
     print("Done", time.time() - startTime )
 
         

--- a/TK_PROP_FX.py
+++ b/TK_PROP_FX.py
@@ -1,8 +1,10 @@
-# Contains properties used for the _____ (TK_PT.py) and relies on the functions from _______ TK_FX.py.
-# It also contains some functions used only with the properties (like update, etc)
-#bl_idname should all be in lowercase for blender 2.8->3.1
+#This file contains functions associated with the custom blender properties (like update, etc) defined in TK_PROP.py. 
+#It relies on the functions from TK_FX.py.
 
-#Devnote: assiging a value of a property using self[<property_name>] won't invoke the class's __setattr__ method unlike self.<property_name>
+
+#Devnote_1: assiging a value of a property using self[<property_name>] won't invoke the class's __setattr__ method unlike self.<property_name>
+#Devnote_2: bl_idname should all be in lowercase for blender 2.8 and above with no spaces.
+
 
 import bpy
 import re
@@ -17,11 +19,6 @@ import time
 from.TK_FX import *
 
 
-
-# SK_copy = None
-
-# def lol():
-#     print("Update!!!!")
 
 #____________________File related functions______________
 def GetAddonsFolderName_propfx():
@@ -43,7 +40,7 @@ def GetAddonsFolderName_propfx():
 
 
 def FileExistenceTester(Folder,name):
-#Works fine
+
     script_file = os.path.realpath(__file__)
     directory_ = os.path.dirname(script_file)
 
@@ -57,6 +54,7 @@ def FileExistenceTester(Folder,name):
     return os.path.exists(GlobalPath)
 
 def Find_File_Names(FolderName, FileType):
+
     script_file = os.path.realpath(__file__)
     directory_ = os.path.dirname(script_file)
 
@@ -90,8 +88,6 @@ def FileCreater(Folder,name):
     directory = bpy.utils.user_resource('SCRIPTS',path= "addons")
     AddonFolder = GetAddonsFolderName_propfx()
 
-    #Tests if a txt file with the name 'name' exists in the folder called "Folder"
-    # Path = 'Rename_Presets/'+ name +'.txt'
     Path = Folder+'/'+ name +'.txt'
     GlobalPath = directory+'/'+AddonFolder+'/'+Path
 
@@ -189,14 +185,6 @@ def Generate_Enum_for_BoneMerger(self, context):
         
     return Enums
 
-
-# def SK_hierarchy_disabler_update(self, context):
-#     #set boolproperty back to false and let it do all the rest
-#     # context.scene.bone_isolation_switch = False
-#     print("Whatever")
-    
-#     #(restore armature hierarchy back to default
-#     #adjust the pose of each bone correctly)
 
 def SK_hierarchy_disabler_poll(self, object):
     return object.type == 'ARMATURE'
@@ -420,7 +408,7 @@ def Generate_Enum_from_Rename_Preset_Collection(self, context):
 
 
 def InitializeBoneRenamerEnumerator():
-    # print("lmao")
+
     # for root, dirs, files in os.walk("Skeletons"):
     PresetNames = Find_File_Names('Rename_Presets', ".txt")
     bpy.context.scene.preset_collection.clear()
@@ -440,45 +428,6 @@ def InitializeBoneRenamerEnumerator():
         bpy.context.scene.preset_enum = '0'
 
 
-    #     Path = 'Rename_Presets/'+ file +'.txt'
-
-    #     GlobalPath = directory+'/'+AddonFolder+'/'+Path
-
-    #     with open(GlobalPath,"r") as f:
-    #         lines = f.readlines()
-    #         print(MaxLines, len(lines))
-    #         if len(lines) > MaxLines:
-    #             MaxLines = len(lines)
-
-    #     print(MaxLines, "maxlines")
-    # #initialize bone_rename_list based on the longest list to save time
-    # for x in range(0, MaxLines):
-    #     bpy.context.scene.bone_rename_list.add()
-
-    # for root, dirs, files in os.walk("Rename_Presets"):
-    #     for file in files:
-    #         if file.endswith(".txt"):
-    #             # print(os.path.join(root, file))
-
-                
-    #             Path = os.path.join(root, file)
-    #             start = '\\'
-    #             end = '.'
-    #             PresetName = Path.split(start)[1].split(end)[0]
-
-    #             bpy.context.scene.preset_collection.add()
-    #             bpy.context.scene.preset_collection[int(bpy.context.scene.preset_enum)].RenameListPreset = PresetName
-
-    #             print(PresetName)
-
-
-                
-                # with open(Path) as f:
-                #     lines = f.readlines()
-                #     for line in lines:
-                #         ConvLine = LineInfoConverterForRenamerPresets(line)
-                #         if len(ConvLine) == 2:
-                #             print(ConvLine, len(ConvLine))
                     
 #_____________________________________________________________
 
@@ -536,29 +485,8 @@ def BoneNameUpdateFunction(self, context):
     # print("How are you")
     GlobalPath = directory+'/'+AddonFolder+'/'+Path
     
-    # Path = 'Rename_Presets'+'/'+ context.RenameListPreset +'.txt'
-    # print(Path)
-    # print(Line)
-
-    # WriteBoneRenameItemToTextFile(Path, bpy.context.scene.bone_rename_list_index, Line)
-    # replace_line(Path, bpy.context.scene.bone_rename_list_index, Line)
     SaveBoneRenameList(GlobalPath, collection)
-    # CollectionNames = []
-    # MatchFlag = False
-    # counter = 0
-    # for n,element in enumerate(collection):
-    #     CollectionNames.append(element.RenameListPreset)
-    #     if self.RenameListPreset == element.RenameListPreset and n != indx:
-    #         MatchFlag = True
 
-    # while MatchFlag == True:
-    #     if self.RenameListPreset in CollectionNames:
-    #         MatchFlag = True
-    #         # print("this is is where all the chiz happens")
-    #         self["RenameListPreset"] = self.RenameListPreset + str(counter)
-    #     else:
-    #         MatchFlag = False                  
-    #     counter += 1    
 
 def RenamePresetMainFunction(self, context):
     collection, indx = collection_from_element(self)
@@ -581,12 +509,6 @@ def RenamePresetMainFunction(self, context):
             MatchFlag = False                  
         counter += 1    
     
-    
-    # FileRenamer(Folder ,OldName, NewName)
-    # if MatchFlag == True:
-    #     print("Rename ",CurrentPresetName, "to ", NewPresetName )
-    # print(FileExistenceTester('Rename_Presets',self.RenameListPreset))
-    # return
 
 
 def RenamePresetUpdatedFunction(self, context):
@@ -704,40 +626,6 @@ def RenamerListPopulate():
 
 
 
-
-    
-
-
-# def FillNewPreset():
-#     obj = bpy.context.active_object
-#     Defaul_List = ['MODEL_00', 'BASE', 'Hip', 'Spine1', 'Spine2', 'Neck', 'Head', 'L_Shoulder', 'L_Arm', 'L_ForeArm', 'L_Hand', 'L_Thumb1', 'L_Thumb2', 'L_Thumb3', 'L_Index1', 'L_Index2', 'L_Index3', 'L_Middle1', 'L_Middle2', 'L_Middle3', 'L_Ring1', 'L_Ring2', 'L_Ring3', 'L_Pinky1', 'L_Pinky2', 'L_Pinky3', 'R_Shoulder', 'R_Arm', 'R_ForeArm', 'R_Hand', 'R_Thumb1', 'R_Thumb2', 'R_Thumb3', 'R_Index1', 'R_Index2', 'R_Index3', 'R_Middle1', 'R_Middle2', 'R_Middle3', 'R_Ring1', 'R_Ring2', 'R_Ring3', 'R_Pinky1', 'R_Pinky2', 'R_Pinky3', 'L_UpLeg', 'L_Leg', 'L_Foot', 'L_Toe', 'R_UpLeg', 'R_Leg', 'R_Foot', 'R_Toe' ]
-
-#     if obj is not None:
-#         if obj.type == 'ARMATURE':
-#             try:
-#                 BoneRenameList = AutoDetectBones()
-#                 ClearBoneRenameList()
-#                 for indx,bonename in enumerate(Defaul_List):
-#                     bpy.context.scene.bone_rename_list.add()
-#                     bpy.context.scene.bone_rename_list[indx].New_Name = bonename
-#                     for element in BoneRenameList:
-#                         if element[1]==bonename:
-#                             bpy.context.scene.bone_rename_list[indx].Current_Name = element[0]
-#                             # print(bonename,"--->",element[1])
-#                             break
-#                         else: 
-#                             bpy.context.scene.bone_rename_list[indx].Current_Name = ''
-                    
-
-#             except:
-#                 InitializeRenameList(Defaul_List)
-
-#         else:
-#             InitializeRenameList(Defaul_List)
-#     else:
-#         InitializeRenameList(Defaul_List)
-
-
 def FillNewPreset():
     obj = bpy.context.active_object
     Defaul_List = ['MODEL_00', 'BASE', 'Hip', 'Spine1', 'Spine2', 'Neck', 'Head', 'L_Shoulder', 'L_Arm', 'L_ForeArm', 'L_Hand', 'L_Thumb1', 'L_Thumb2', 'L_Thumb3', 'L_Index1', 'L_Index2', 'L_Index3', 'L_Middle1', 'L_Middle2', 'L_Middle3', 'L_Ring1', 'L_Ring2', 'L_Ring3', 'L_Pinky1', 'L_Pinky2', 'L_Pinky3', 'R_Shoulder', 'R_Arm', 'R_ForeArm', 'R_Hand', 'R_Thumb1', 'R_Thumb2', 'R_Thumb3', 'R_Index1', 'R_Index2', 'R_Index3', 'R_Middle1', 'R_Middle2', 'R_Middle3', 'R_Ring1', 'R_Ring2', 'R_Ring3', 'R_Pinky1', 'R_Pinky2', 'R_Pinky3', 'L_UpLeg', 'L_Leg', 'L_Foot', 'L_Toe', 'R_UpLeg', 'R_Leg', 'R_Foot', 'R_Toe', 'SWG_OPT1_bustL__swing', 'SWG_OPT3_bustR__swing' ]
@@ -782,41 +670,9 @@ def BoneRenamerPresetSelection(self, context):
     # Call function to load preset by changing bone_rename_list
     print("Done", time.time() - startTime )
 
-
-    # for x in range(Counter, len(bpy.context.scene.bone_rename_list)):
-    #     bpy.context.scene.bone_rename_list[x].Current_Name = ""
-    #     bpy.context.scene.bone_rename_list[x].New_Name = ""
-
         
     return
 
-
-
-
-# def GenerateBoneRenamerEnumerator():
-#     # for root, dirs, files in os.walk("Skeletons"):
-#     for root, dirs, files in os.walk("Rename_Presets"):
-#         for file in files:
-#             if file.endswith(".txt"):
-#                 # print(os.path.join(root, file))
-
-                
-#                 Path = os.path.join(root, file)
-#                 start = '\\'
-#                 end = '.'
-#                 PresetName = Path.split(start)[1].split(end)[0]
-#                 print(PresetName)
-#                 with open(Path) as f:
-#                     lines = f.readlines()
-#                     for line in lines:
-#                         ConvLine = LineInfoConverterForRenamerPresets(line)
-#                         if len(ConvLine) == 2:
-#                             print(ConvLine, len(ConvLine))
-                    
-
-
-
-# GenerateBoneRenamerEnumerator()
 
 
 #______________________For simplifier______________________
@@ -830,34 +686,6 @@ def GetBoneSubstringList():
 
     print(BoneSubstrgList, "Just to check")
     return BoneSubstrgList
-
-# #TODO: for simplifier
-# def TemplateBoneSubstrngListGenerate(preset):
-#     #clear current substring list
-#     for indx,item in enumerate(bpy.context.scene.my_list):
-#         bpy.context.scene.my_list.remove(indx)
-
-#     #Generate new list based on the preset choice
-#     if preset == "Default":
-#         list = ["adj", "unused", "ctr", "roll" , "ROLL", "offset", "twist", "fix", "joint", "null"]
-#         for ind,name in enumerate(list):
-#             bpy.context.scene.my_list.add()
-#             bpy.context.scene.my_list[ind].name = list[ind]
-
-# #TODO: for SK gen
-# def Generate_Enum_for_SK_Gen(self, context):
-    
-#     Enum_items = []
-    
-#     # for indx,test_number in enumerate(context.scene.preset_collection):
-        
-#     #     data = str(test_number.RenameListPreset)
-#     #     Strindx = str(indx)
-#     #     item = (Strindx, data, '')
-        
-#     #     Enum_items.append(item)
-        
-#     return Enum_items
 
 
 

--- a/TK_SK_CH.py
+++ b/TK_SK_CH.py
@@ -15,7 +15,7 @@ import addon_utils
 
 # To expand compatability beyond Tekken 7
 Bonedict = {
-        'Hips': 'Hip',
+        'Hip': 'Hip',
         'Spine1': 'Spine1', 
         'Spine2': 'Spine2', 
         'Neck': 'Neck', 
@@ -313,17 +313,31 @@ def GetAddonsFolderName_SK_CH_Gen():
     print(addon_folder)
     return addon_folder
 
+def GetAddonsFolderPath_SK_CH_Gen():
+    addon_folder_path = None
+    
+    for mod in addon_utils.modules():
+        if mod.bl_info.get('name') == "TK7_SK_CH":
+            addon_folder_path = os.path.dirname(mod.__file__)
+            break
+    
+    if addon_folder_path is None:
+        raise Exception("Could not retrieve the TK7_SK_CH addon path.")
+    
+    return addon_folder_path
+
 def ReadSKdatafile(char):
     script_file = os.path.realpath(__file__)
     directory_ = os.path.dirname(script_file)
 
     directory = bpy.utils.user_resource('SCRIPTS',path="addons")
-    AddonFolder = GetAddonsFolderName_SK_CH_Gen()
+    AddonFolderPath = GetAddonsFolderPath_SK_CH_Gen()
 
     #Function that reads the SK data files and returns a list with the lines
-    Path = 'Skeletons/'+ 'SK_CH_'+ char + '.txt'
-    
-    GlobalPath = directory+'/'+AddonFolder+'/'+Path
+    File = + 'SK_CH_'+ char + '.txt'
+    # GlobalPath = directory+'/'+AddonFolder+'/'+Path
+
+    GlobalPath = os.path.join(AddonFolderPath, 'Skeletons', File)
     print(GlobalPath)
     with open(GlobalPath) as f:
         lines = f.readlines()


### PR DESCRIPTION
- Utilizes os.path.join to combine paths which makes the paths valid for other platforms.

- Adds a variant for GetAddonsFolderName_SK_CH_Gen that returns the full path of the addon folder. The variant is called GetAddonsFolderPath_SK_CH_Gen.

- Adds a variant for GetAddonsFolderName_propfx that returns the full path of the addon folder. The variant is called GetAddonsFolderPath_propfx.
